### PR TITLE
Fix for IOTCLT-249 Notify feature is not working correctly

### DIFF
--- a/source/include/threadhelper.h
+++ b/source/include/threadhelper.h
@@ -70,8 +70,7 @@ class ThreadHelper
 
 public:
 
-     pthread_t _thread_id;
-     pthread_mutex_t lock;
+     pthread_t _thread_id;     
 
 friend class Test_ThreadHelper;
 };

--- a/source/m2mtimerpimpl.cpp
+++ b/source/m2mtimerpimpl.cpp
@@ -83,7 +83,7 @@ void M2MTimerPimpl::run()
 {
     if(!_dtls_type){
         usleep(_interval * 1000);
-        timer_expired();        
+        timer_expired();
     }else{
         usleep(_intermediate_interval * 1000);
         _status++;


### PR DESCRIPTION
- Fix for IOTCLT-249 Notify feature is not working correctly.
- Also fixes error IOTCLT-263 Notify is send only twice and after that pmax timer is never expiring
- Unit tests updated
