### PR TITLE
Moving TRACE_GROUP define from header to source files to avoid multip…

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -21,6 +21,8 @@
 #include "mbed-client/m2msecurity.h"
 #include "mbed-trace/mbed_trace.h"
 
+#define TRACE_GROUP "mClt"
+
 M2MConnectionHandlerPimpl::M2MConnectionHandlerPimpl(M2MConnectionHandler* base, M2MConnectionObserver &observer,
                                                      M2MConnectionSecurity *sec,
                                                      M2MInterface::BindingMode mode,


### PR DESCRIPTION
…le definition error.