### PR TITLE
m2mtimer: Fix use of uninitialize memory in stop_timer()

### DIFF
--- a/source/m2mtimerpimpl.cpp
+++ b/source/m2mtimerpimpl.cpp
@@ -74,6 +74,8 @@ void M2MTimerPimpl::stop_timer()
 {
     if (!_status) {
 
+        _timer_specs.it_interval.tv_sec = 0;
+        _timer_specs.it_interval.tv_nsec = 0;
         _timer_specs.it_value.tv_sec = 0;
         _timer_specs.it_value.tv_nsec = 0;
 


### PR DESCRIPTION
Valgrind spotted out a use of uninitialized memory in
M2MTimerPimpl::stop_timer(). Fix this by initializing the
it_interval of _timer_specs before passing it to timer_settime().

Warning being fixed by this commit:
---8<---8<---
==30446== Syscall param timer_settime(value) points to uninitialised byte(s)
==30446==    at 0x5059411: timer_settime@@GLIBC_2.3.3 (timer_settime.c:43)
==30446==    by 0x4915C7: M2MTimerPimpl::stop_timer() (m2mtimerpimpl.cpp:80)
==30446==    by 0x4911AF: M2MTimer::stop_timer() (m2mtimer.cpp:47)
==30446==    by 0x44B317: M2MNsdlInterface::send_register_message(unsigned char*, unsigned char, unsigned short, sn_nsdl_addr_type_) (m2mnsdlinterface.cpp:277)
==30446==    by 0x447E6D: M2MInterfaceImpl::state_register_address_resolved(EventData*) (m2minterfaceimpl.cpp:733)
==30446==    by 0x448CBA: M2MInterfaceImpl::state_function(unsigned char, EventData*) (m2minterfaceimpl.cpp:938)
==30446==    by 0x448A4D: M2MInterfaceImpl::state_engine() (m2minterfaceimpl.cpp:898)
==30446==    by 0x448964: M2MInterfaceImpl::internal_event(unsigned char, EventData*) (m2minterfaceimpl.cpp:881)
==30446==    by 0x445BEF: M2MInterfaceImpl::address_ready(M2MConnectionObserver::SocketAddress const&, M2MConnectionObserver::ServerType, unsigned short) (m2minterfaceimpl.cpp:481)
==30446==    by 0x48E376: M2MConnectionHandlerPimpl::resolve_server_address(m2m::String const&, unsigned short, M2MConnectionObserver::ServerType, M2MSecurity const*) (m2mconnectionhandlerpimpl.cpp:147)
==30446==    by 0x48D81E: M2MConnectionHandler::resolve_server_address(m2m::String const&, unsigned short, M2MConnectionObserver::ServerType, M2MSecurity const*) (m2mconnectionhandler.cpp:51)
==30446==    by 0x4476B6: M2MInterfaceImpl::state_register(EventData*) (m2minterfaceimpl.cpp:675)
==30446==  Address 0x5e48770 is 128 bytes inside a block of size 168 alloc'd
==30446==    at 0x4C2B0E0: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==30446==    by 0x490F2F: M2MTimer::M2MTimer(M2MTimerObserver&) (m2mtimer.cpp:25)
==30446==    by 0x449D9C: M2MNsdlInterface::M2MNsdlInterface(M2MNsdlObserver&) (m2mnsdlinterface.cpp:55)
==30446==    by 0x4436C8: M2MInterfaceImpl::M2MInterfaceImpl(M2MInterfaceObserver&, m2m::String const&, m2m::String const&, int, unsigned short, m2m::String const&, M2MInterface::BindingMode, M2MInterface::NetworkStack, m2m::String const&) (m2minterfaceimpl.cpp:41)
==30446==    by 0x4357DB: M2MInterfaceFactory::create_interface(M2MInterfaceObserver&, m2m::String const&, m2m::String const&, int, unsigned short, m2m::String const&, M2MInterface::BindingMode, M2MInterface::NetworkStack, m2m::String const&) (m2minterfacefactory.cpp:69)
==30446==    by 0x41ECD2: M2MLWClient::create_interface(char const*, char const*, int, unsigned short, char const*, unsigned char, unsigned char) (lwm2mtest.cpp:93)
==30446==    by 0x42DF6B: lwm2m_client_setup_command(int, char**) (cmd_lwm2m.cpp:519)
==30446==    by 0x42CEF9: lwm2m_client_command(int, char**) (cmd_lwm2m.cpp:362)
==30446==    by 0x46D0E5: cmd_run (ns_cmdline.c:780)
==30446==    by 0x46B973: cmd_next (ns_cmdline.c:376)
==30446==    by 0x41D633: cmd_ready_cb(int) (cmd_commands.cpp:54)
==30446==    by 0x46B865: cmd_ready (ns_cmdline.c:359)