### PR TITLE
Fix error: IOTCLT-850 During reconnections, resolve_hostname() should…

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -211,6 +211,7 @@ void M2MConnectionHandlerPimpl::data_receive(void *object)
         M2MConnectionHandlerPimpl *thread_object = static_cast<M2MConnectionHandlerPimpl*> (object);
         if(thread_object && _listen_thread > 0) {
             pthread_join(_listen_thread, NULL);
+            _listen_thread = 0;
         }
         int16_t rcv_size = -1;
         fd_set read_fds;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -209,7 +209,7 @@ void M2MConnectionHandlerPimpl::data_receive(void *object)
     tr_debug("M2MConnectionHandlerPimpl::data_receive");
     if(object != NULL){
         M2MConnectionHandlerPimpl *thread_object = static_cast<M2MConnectionHandlerPimpl*> (object);
-        if(thread_object) {
+        if(thread_object && _listen_thread > 0) {
             pthread_join(_listen_thread, NULL);
         }
         int16_t rcv_size = -1;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -71,7 +71,8 @@ M2MConnectionHandlerPimpl::~M2MConnectionHandlerPimpl()
 
     if(_listen_thread > 0) {
         if (!pthread_equal(_listen_thread, pthread_self())) {
-            pthread_detach(_listen_thread);
+            pthread_cancel(_listen_thread);
+            pthread_join(_listen_thread, NULL);
         }
     }
 
@@ -434,6 +435,7 @@ bool M2MConnectionHandlerPimpl::resolve_hostname(const char *address,
     if(_socket_server > 0) {
         close(_socket_server);
         _socket_server = -1;
+        pthread_join(_listen_thread, NULL);
     }
     create_socket();
     if (_socket_server != -1) {

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -436,6 +436,7 @@ bool M2MConnectionHandlerPimpl::resolve_hostname(const char *address,
         close(_socket_server);
         _socket_server = -1;
         pthread_join(_listen_thread, NULL);
+        _listen_thread = 0;
     }
     create_socket();
     if (_socket_server != -1) {


### PR DESCRIPTION
… wait for 'listener' thread to terminate before creating a new socket