### PR TITLE
Initialize eventloop in both timer and connection handler

### DIFF
--- a/source/eventloop.h
+++ b/source/eventloop.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EVENTLOOP_H__
+#define EVENTLOOP_H__
+
+#include "ns_hal_init.h"
+
+#ifdef MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
+#define MBED_CLIENT_EVENT_LOOP_SIZE MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
+#else
+#define MBED_CLIENT_EVENT_LOOP_SIZE 1024
+#endif
+
+inline void eventloop_init() {
+    ns_hal_init(NULL, MBED_CLIENT_EVENT_LOOP_SIZE, NULL, NULL);
+}
+
+#endif /* EVENTLOOP_H__ */

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -36,6 +36,7 @@
 #include "eventOS_event.h"
 
 #include "mbed-trace/mbed_trace.h"
+#include "eventloop.h"
 
 #define TRACE_GROUP "mClt"
 
@@ -146,6 +147,8 @@ _net_iface(0),
 _socket_address_len(0),
 _socket_state(ESocketStateDisconnected)
 {
+
+    eventloop_init();
 
     memset(&_address, 0, sizeof _address);
     memset(&_socket_address, 0, sizeof(struct sockaddr_storage));

--- a/source/m2mtimerpimpl.cpp
+++ b/source/m2mtimerpimpl.cpp
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <time.h>
 
+#include "eventloop.h"
 #include "mbed-client-linux/m2mtimerpimpl.h"
 #include "mbed-client/m2mtimerobserver.h"
 #include "mbed-client/m2mvector.h"
@@ -24,16 +25,10 @@
 #include "eventOS_event.h"
 #include "eventOS_event_timer.h"
 #include "eventOS_scheduler.h"
-#include "ns_hal_init.h"
+
 
 #define MBED_CLIENT_TIMER_TASKLET_INIT_EVENT 0 // Tasklet init occurs always when generating a tasklet
 #define MBED_CLIENT_TIMER_EVENT 10
-
-#ifdef MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
-#define MBED_CLIENT_EVENT_LOOP_SIZE MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
-#else
-#define MBED_CLIENT_EVENT_LOOP_SIZE 1024
-#endif
 
 int8_t M2MTimerPimpl::_tasklet_id = -1;
 
@@ -80,7 +75,7 @@ M2MTimerPimpl::M2MTimerPimpl(M2MTimerObserver& observer)
   _dtls_type(false),
   _started(false)
 {
-    ns_hal_init(NULL, MBED_CLIENT_EVENT_LOOP_SIZE, NULL, NULL);
+    eventloop_init();
     eventOS_scheduler_mutex_wait();
     if (_tasklet_id < 0) {
         _tasklet_id = eventOS_event_handler_create(tasklet_func, MBED_CLIENT_TIMER_TASKLET_INIT_EVENT);


### PR DESCRIPTION
Fixes issue where eventloop didn't get initialized for connection handler if connection handler was initialized before a timer.